### PR TITLE
Added coordinates from City database

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -29,12 +29,15 @@ type Server struct {
 }
 
 type Response struct {
-	IP         net.IP `json:"ip"`
-	IPDecimal  uint64 `json:"ip_decimal"`
-	Country    string `json:"country,omitempty"`
-	CountryISO string `json:"country_iso,omitempty"`
-	City       string `json:"city,omitempty"`
-	Hostname   string `json:"hostname,omitempty"`
+	IP                           net.IP `json:"ip"`
+	IPDecimal                    uint64 `json:"ip_decimal"`
+	Country                      string `json:"country,omitempty"`
+	CountryISO                   string `json:"country_iso,omitempty"`
+	IsInEuropeanUnion            bool `json:"is_in_european_union,omitempty"`
+	City                         string `json:"city,omitempty"`
+	Hostname                     string `json:"hostname,omitempty"`
+	LocationLatitude             float64 `json:"location_latitude,omitempty"`
+	LocationLongitude            float64 `json:"location_longitude,omitempty"`
 }
 
 type PortResponse struct {
@@ -76,12 +79,15 @@ func (s *Server) newResponse(r *http.Request) (Response, error) {
 		hostname, _ = s.LookupAddr(ip)
 	}
 	return Response{
-		IP:         ip,
-		IPDecimal:  ipDecimal,
-		Country:    country.Name,
-		CountryISO: country.ISO,
-		City:       city,
-		Hostname:   hostname,
+		IP:                           ip,
+		IPDecimal:                    ipDecimal,
+		Country:                      country.Name,
+		CountryISO:                   country.ISO,
+		IsInEuropeanUnion:            country.IsInEuropeanUnion,
+		City:                         city.Name,
+		Hostname:                     hostname,
+		LocationLatitude:             city.Latitude,
+		LocationLongitude:            city.Longitude,
 	}, nil
 }
 
@@ -136,6 +142,19 @@ func (s *Server) CLICityHandler(w http.ResponseWriter, r *http.Request) *appErro
 		return internalServerError(err)
 	}
 	fmt.Fprintln(w, response.City)
+	return nil
+}
+
+func (s *Server) CLICoordinatesHandler(w http.ResponseWriter, r *http.Request) *appError {
+	response, err := s.newResponse(r)
+	if err != nil {
+		return internalServerError(err)
+	}
+	var str string
+	str += FloatToString(response.LocationLatitude)
+	str += ","
+	str += FloatToString(response.LocationLongitude)
+	fmt.Fprintln(w, str)
 	return nil
 }
 
@@ -253,6 +272,7 @@ func (s *Server) Handler() http.Handler {
 		r.Route("GET", "/country", s.CLICountryHandler)
 		r.Route("GET", "/country-iso", s.CLICountryISOHandler)
 		r.Route("GET", "/city", s.CLICityHandler)
+		r.Route("GET", "/coordinates", s.CLICoordinatesHandler)
 	}
 
 	// Browser
@@ -268,4 +288,8 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) ListenAndServe(addr string) error {
 	return http.ListenAndServe(addr, s.Handler())
+}
+
+func FloatToString(input_num float64) string {
+	return strconv.FormatFloat(input_num, 'f', 6, 64)
 }

--- a/http/http.go
+++ b/http/http.go
@@ -36,8 +36,8 @@ type Response struct {
 	IsInEuropeanUnion            bool `json:"is_in_european_union,omitempty"`
 	City                         string `json:"city,omitempty"`
 	Hostname                     string `json:"hostname,omitempty"`
-	LocationLatitude             float64 `json:"location_latitude,omitempty"`
-	LocationLongitude            float64 `json:"location_longitude,omitempty"`
+	Latitude                     float64 `json:"location_latitude,omitempty"`
+	Longitude                    float64 `json:"location_longitude,omitempty"`
 }
 
 type PortResponse struct {
@@ -86,8 +86,8 @@ func (s *Server) newResponse(r *http.Request) (Response, error) {
 		IsInEuropeanUnion:            country.IsInEuropeanUnion,
 		City:                         city.Name,
 		Hostname:                     hostname,
-		LocationLatitude:             city.Latitude,
-		LocationLongitude:            city.Longitude,
+		Latitude:                     city.Latitude,
+		Longitude:                    city.Longitude,
 	}, nil
 }
 

--- a/http/http.go
+++ b/http/http.go
@@ -150,11 +150,7 @@ func (s *Server) CLICoordinatesHandler(w http.ResponseWriter, r *http.Request) *
 	if err != nil {
 		return internalServerError(err)
 	}
-	var str string
-	str += FloatToString(response.LocationLatitude)
-	str += ","
-	str += FloatToString(response.LocationLongitude)
-	fmt.Fprintln(w, str)
+	fmt.Fprintf(w, "%s, %s\n", formatCoordinate(response.Latitude), formatCoordinate(response.Longitude))
 	return nil
 }
 
@@ -290,6 +286,6 @@ func (s *Server) ListenAndServe(addr string) error {
 	return http.ListenAndServe(addr, s.Handler())
 }
 
-func FloatToString(input_num float64) string {
-	return strconv.FormatFloat(input_num, 'f', 6, 64)
+func formatCoordinate(c float64) string {
+	return strconv.FormatFloat(c, 'f', 6, 64)
 }

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -20,7 +20,10 @@ func (t *testDb) Country(net.IP) (database.Country, error) {
 	return database.Country{Name: "Elbonia", ISO: "EB"}, nil
 }
 
-func (t *testDb) City(net.IP) (string, error) { return "Bornyasherk", nil }
+func (t *testDb) City(net.IP) (database.City, error) {
+	return database.City{Name: "Bornyasherk"}, nil
+}
+
 func (t *testDb) IsEmpty() bool               { return false }
 
 func testServer() *Server {

--- a/iputil/database/database.go
+++ b/iputil/database/database.go
@@ -89,10 +89,10 @@ func (g *geoip) City(ip net.IP) (City, error) {
 	if c, exists := record.City.Names["en"]; exists {
 		city.Name = c
 	}
-	if math.IsNaN(record.Location.Latitude) == false {
+	if !math.IsNaN(record.Location.Latitude) {
 		city.Latitude = record.Location.Latitude
 	}
-	if math.IsNaN(record.Location.Longitude) == false {
+	if !math.IsNaN(record.Location.Longitude) {
 		city.Longitude = record.Location.Longitude
 	}
 	return city, nil

--- a/iputil/database/database.go
+++ b/iputil/database/database.go
@@ -2,19 +2,27 @@ package database
 
 import (
 	"net"
+	"math"
 
 	geoip2 "github.com/oschwald/geoip2-golang"
 )
 
 type Client interface {
 	Country(net.IP) (Country, error)
-	City(net.IP) (string, error)
+	City(net.IP) (City, error)
 	IsEmpty() bool
 }
 
 type Country struct {
-	Name string
-	ISO  string
+	Name              string
+	ISO               string
+	IsInEuropeanUnion bool
+}
+
+type City struct {
+	Name      string
+	Latitude  float64
+	Longitude float64
 }
 
 type geoip struct {
@@ -62,21 +70,32 @@ func (g *geoip) Country(ip net.IP) (Country, error) {
 	if record.RegisteredCountry.IsoCode != "" && country.ISO == "" {
 		country.ISO = record.RegisteredCountry.IsoCode
 	}
+	country.IsInEuropeanUnion = record.Country.IsInEuropeanUnion
+	if record.RegisteredCountry.IsoCode != "" && country.ISO == "" {
+		country.IsInEuropeanUnion = record.RegisteredCountry.IsInEuropeanUnion
+	}
 	return country, nil
 }
 
-func (g *geoip) City(ip net.IP) (string, error) {
+func (g *geoip) City(ip net.IP) (City, error) {
+	city := City{}
 	if g.city == nil {
-		return "", nil
+		return city, nil
 	}
 	record, err := g.city.City(ip)
 	if err != nil {
-		return "", err
+		return city, err
 	}
-	if city, exists := record.City.Names["en"]; exists {
-		return city, nil
+	if c, exists := record.City.Names["en"]; exists {
+		city.Name = c
 	}
-	return "", nil
+	if math.IsNaN(record.Location.Latitude) == false {
+		city.Latitude = record.Location.Latitude
+	}
+	if math.IsNaN(record.Location.Longitude) == false {
+		city.Longitude = record.Location.Longitude
+	}
+	return city, nil
 }
 
 func (g *geoip) IsEmpty() bool {


### PR DESCRIPTION
Hi

I added latitude and longitude as well as 'Is in European Union'.

{
"ip": "ip",
"ip_decimal": 2130706433,
"country": "Denmark",
"country_iso": "DK",
"is_in_european_union": true,
"city": "Copenhagen",
"location_latitude": 56.0,
"location_longitude": 10.0
}

I am not sure whether these additions is in your scope. What do you think?

You can read more about what variables is available to add: https://github.com/oschwald/geoip2-golang/blob/b1581f42de7092eb285fa413a1310f90c4f328fb/reader.go