### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Compile
-FROM golang:alpine AS build
-ADD . /go/src/github.com/mpolden/ipd
-WORKDIR /go/src/github.com/mpolden/ipd
-RUN apk --update add git
-RUN go get -d -v ./...
+FROM golang:1.11-alpine AS build
+ADD . /go/src/github.com/mpolden/echoip
+WORKDIR /go/src/github.com/mpolden/echoip
+RUN apk --update add git gcc musl-dev
+ENV GO111MODULE=on
+RUN go get -d -v .
 RUN go install ./...
 
 # Run
 FROM alpine
 RUN mkdir -p /opt/
-COPY --from=build /go/bin/ipd /opt/
+COPY --from=build /go/bin/echoip /opt/
 WORKDIR /opt/
-ENTRYPOINT ["/opt/ipd"]
+ENTRYPOINT ["/opt/echoip"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Compile
+FROM golang:alpine AS build
+ADD . /go/src/github.com/mpolden/ipd
+WORKDIR /go/src/github.com/mpolden/ipd
+RUN apk --update add git
+RUN go get -d -v ./...
+RUN go install ./...
+
+# Run
+FROM alpine
+RUN mkdir -p /opt/
+COPY --from=build /go/bin/ipd /opt/
+WORKDIR /opt/
+ENTRYPOINT ["/opt/ipd"]


### PR DESCRIPTION
I want to make your awesome project very easy to deploy. A big step forward would be to have an always up-to-date Docker image on Docker Hub.

In this PR I made a Dockerfile, it makes a very tiny Docker container running ipd.

The ideal solution would be to make a Travis job to publish the docker image to Docker Hub, on daily basis + when you push to `master` — that way without any action from your side, a Docker image will always be up to date.

I have already configured such workflow a couple of times for my own projects, e.g. [here](https://github.com/maximbaz/docker-arch-build-aur) and [here](https://github.com/maximbaz/docker-emojione-fonts-build). Their `.travis.yml` is almost identical, and we would need to make something similar for you too. I will help you configure this, but some parts you would need to do yourself, as I can't access your project on Travis. Do you agree to do this?