### PR TITLE
changed env var in makefile to builtin var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ databases := GeoLite2-City GeoLite2-Country
 
 $(databases):
 	mkdir -p data
-	curl -fsSL -m 30 https://geolite.maxmind.com/download/geoip/database/$@.tar.gz | tar $(TAR_OPTS) --strip-components=1 -C $(PWD)/data -xzf - '*.mmdb'
+	curl -fsSL -m 30 https://geolite.maxmind.com/download/geoip/database/$@.tar.gz | tar $(TAR_OPTS) --strip-components=1 -C $(CURDIR)/data -xzf - '*.mmdb'
 	test ! -f data/GeoLite2-City.mmdb || mv data/GeoLite2-City.mmdb data/city.mmdb
 	test ! -f data/GeoLite2-Country.mmdb || mv data/GeoLite2-Country.mmdb data/country.mmdb
 


### PR DESCRIPTION
The Makefile is using the environment variable PWD. This can be problematic if using 'sudo'. The PWD variable is not passed through unless the '-E' flag is used.GNU make has a builtin CURDIR variable for the current working directory that does work with and without 'sudo'.