### PR TITLE
port scan: change highest allowed tcp port to 65535 (before: 65355 - typo?)

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -113,7 +113,7 @@ func (s *Server) newResponse(r *http.Request) (Response, error) {
 func (s *Server) newPortResponse(r *http.Request) (PortResponse, error) {
 	lastElement := filepath.Base(r.URL.Path)
 	port, err := strconv.ParseUint(lastElement, 10, 16)
-	if err != nil || port < 1 || port > 65355 {
+	if err != nil || port < 1 || port > 65535 {
 		return PortResponse{Port: port}, fmt.Errorf("invalid port: %d", port)
 	}
 	ip, err := ipFromRequest(s.IPHeaders, r)

--- a/http/http.go
+++ b/http/http.go
@@ -114,7 +114,7 @@ func (s *Server) newPortResponse(r *http.Request) (PortResponse, error) {
 	lastElement := filepath.Base(r.URL.Path)
 	port, err := strconv.ParseUint(lastElement, 10, 16)
 	if err != nil || port < 1 || port > 65535 {
-		return PortResponse{Port: port}, fmt.Errorf("invalid port: %d", port)
+		return PortResponse{Port: port}, fmt.Errorf("invalid port: %s", lastElement)
 	}
 	ip, err := ipFromRequest(s.IPHeaders, r)
 	if err != nil {

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -132,7 +132,7 @@ func TestJSONHandlers(t *testing.T) {
 		{s.URL, `{"ip":"127.0.0.1","ip_decimal":2130706433,"country":"Elbonia","country_eu":false,"country_iso":"EB","city":"Bornyasherk","hostname":"localhost","latitude":63.416667,"longitude":10.416667}`, 200},
 		{s.URL + "/port/foo", `{"error":"Invalid port: 0"}`, 400},
 		{s.URL + "/port/0", `{"error":"Invalid port: 0"}`, 400},
-		{s.URL + "/port/65356", `{"error":"Invalid port: 65356"}`, 400},
+		{s.URL + "/port/65357", `{"error":"Invalid port: 65357"}`, 400},
 		{s.URL + "/port/31337", `{"ip":"127.0.0.1","port":31337,"reachable":true}`, 200},
 		{s.URL + "/foo", `{"error":"404 page not found"}`, 404},
 		{s.URL + "/health", `{"status":"OK"}`, 200},

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -132,7 +132,7 @@ func TestJSONHandlers(t *testing.T) {
 		{s.URL, `{"ip":"127.0.0.1","ip_decimal":2130706433,"country":"Elbonia","country_eu":false,"country_iso":"EB","city":"Bornyasherk","hostname":"localhost","latitude":63.416667,"longitude":10.416667}`, 200},
 		{s.URL + "/port/foo", `{"error":"Invalid port: 0"}`, 400},
 		{s.URL + "/port/0", `{"error":"Invalid port: 0"}`, 400},
-		{s.URL + "/port/65537", `{"error":"Invalid port: 65535"}`, 400},
+		{s.URL + "/port/65537", `{"error":"Invalid port: 65537"}`, 400},
 		{s.URL + "/port/31337", `{"ip":"127.0.0.1","port":31337,"reachable":true}`, 200},
 		{s.URL + "/foo", `{"error":"404 page not found"}`, 404},
 		{s.URL + "/health", `{"status":"OK"}`, 200},

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -132,7 +132,7 @@ func TestJSONHandlers(t *testing.T) {
 		{s.URL, `{"ip":"127.0.0.1","ip_decimal":2130706433,"country":"Elbonia","country_eu":false,"country_iso":"EB","city":"Bornyasherk","hostname":"localhost","latitude":63.416667,"longitude":10.416667}`, 200},
 		{s.URL + "/port/foo", `{"error":"Invalid port: 0"}`, 400},
 		{s.URL + "/port/0", `{"error":"Invalid port: 0"}`, 400},
-		{s.URL + "/port/65357", `{"error":"Invalid port: 65357"}`, 400},
+		{s.URL + "/port/65537", `{"error":"Invalid port: 65537"}`, 400},
 		{s.URL + "/port/31337", `{"ip":"127.0.0.1","port":31337,"reachable":true}`, 200},
 		{s.URL + "/foo", `{"error":"404 page not found"}`, 404},
 		{s.URL + "/health", `{"status":"OK"}`, 200},

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -132,7 +132,7 @@ func TestJSONHandlers(t *testing.T) {
 		{s.URL, `{"ip":"127.0.0.1","ip_decimal":2130706433,"country":"Elbonia","country_eu":false,"country_iso":"EB","city":"Bornyasherk","hostname":"localhost","latitude":63.416667,"longitude":10.416667}`, 200},
 		{s.URL + "/port/foo", `{"error":"Invalid port: 0"}`, 400},
 		{s.URL + "/port/0", `{"error":"Invalid port: 0"}`, 400},
-		{s.URL + "/port/65537", `{"error":"Invalid port: 65537"}`, 400},
+		{s.URL + "/port/65537", `{"error":"Invalid port: 65535"}`, 400},
 		{s.URL + "/port/31337", `{"ip":"127.0.0.1","port":31337,"reachable":true}`, 200},
 		{s.URL + "/foo", `{"error":"404 page not found"}`, 404},
 		{s.URL + "/health", `{"status":"OK"}`, 200},


### PR DESCRIPTION
Change highest allowed tcp port to 65535 (instead of 65355 - potential typo?).

Background: The highest ipv4 tcp port is 65535, but `echoip` only allowed to scan tcp ports up to including 65355. Any higher port resulted in an `invalid port` error message.