### PR TITLE
Allow overriding image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMAGE := mpolden/echoip
+DOCKER_IMAGE ?= mpolden/echoip
 OS := $(shell uname)
 ifeq ($(OS),Linux)
 	TAR_OPTS := --wildcards


### PR DESCRIPTION
This can be done with ``make docker-build DOCKER_IMAGE=supersandro2000/echoip``