### PR TITLE
http: enable getting json from another IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ between IPv4 and IPv6 lookup.
 * JSON output
 * ASN, country and city lookup using the MaxMind GeoIP database
 * Port testing
+* All endpoints (except `/port`) can return information about a custom IP address specified via `?ip=` query parameter
 * Open source under the [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause)
 
 ## Why?

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@ $ http {{ .Host }}/asn
 $ http {{ .Host }}/json
 {{ .JSON }}</pre>
         <p>Setting the <code>Accept: application/json</code> header also works as expected.</p>
+	<p>All endpoints (except <code>/port</code>) can return information about a custom IP address specified via <code>?ip=</code> query parameter.</p>
         <h2>Plain output</h2>
         <p>Always returns the IP address including a trailing newline, regardless of user agent.</p>
         <pre>


### PR DESCRIPTION
This commit is a slight departure from the perspective of getting
information only about the caller's ip, but now allows to get
information from arbitrary IPs.

```shell
$ ip=$(dig another.example.com | grep ^[[:alpha:]] | awk '{ print $5 }')
$ curl -sSL myechoip.example.com/ip/$ip
{"ip":"172.217.15.78","ip_decimal":2899906382,"country":"United States","country_iso":"US","country_eu":false,"latitude":37.751,"longitude":-97.822,"time_zone":"America/Chicago","hostname":"iad23s63-in-f14.1e100.net"}
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>