### PR TITLE
Sending accurate UserAgent rather than the cached one

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -111,6 +111,7 @@ func (s *Server) newResponse(r *http.Request) (Response, error) {
 	}
 	response, ok := s.cache.Get(ip)
 	if ok {
+		// Not Caching the userAgent as it can vary for a given IP
 		response.UserAgent = userAgentFromRequest(r)
 		return *response, nil
 	}


### PR DESCRIPTION
Currently, if two devices with the same apparent ip send a request, they will get the UserAgent of the first one. To avoid this I've overridden the UserAgent of the response to match the incoming one, if it was cached.