### PR TITLE
Use http:// with fetch example

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ $ http -b {{ .Host }}
 $ wget -qO- {{ .Host }}
 {{ .IP }}
 
-$ fetch -qo- https://{{ .Host }}
+$ fetch -qo- http://{{ .Host }}
 {{ .IP }}
 
 $ bat -print=b {{ .Host }}/ip


### PR DESCRIPTION
This resolves an issue for those serving echoip exclusively over HTTP.

Those using HTTPS are likely to have a redirect in place from HTTP to HTTPS, which fetch will follow. Whereas the reverse is less likely.

Using http:// as the default here is likely to be more widely compatible.

Edit: I had originally removed the protocol completely in this PR, but then realised that `fetch` requires a protocol.