### PR TITLE
Include a link to bat

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,7 @@
         <p><code class="ip">{{ .IP }}</code></p>
         <p>Multiple command line HTTP clients are supported,
           including <a href="https://curl.haxx.se/">curl</a>, <a href="https://github.com/jkbrzt/httpie">httpie</a>, <a href="https://www.gnu.org/software/wget/">GNU
-            Wget</a>
-          and <a href="https://www.freebsd.org/cgi/man.cgi?fetch(1)">fetch</a>.</p>
+            Wget</a>, <a href="https://www.freebsd.org/cgi/man.cgi?fetch(1)">fetch</a>, and <a href="https://github.com/astaxie/bat">bat</a>.</p>
       </div>
     </div>
     <div class="pure-g">


### PR DESCRIPTION
Indlude a link to bat, since an example is provided for it.