### PR TITLE
add cli detection for httpie-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ between IPv4 and IPv6 lookup.
 * Fast
 * Supports IPv6
 * Supports HTTPS
-* Supports common command-line clients (e.g. `curl`, `httpie`, `wget` and `fetch`)
+* Supports common command-line clients (e.g. `curl`, `httpie`, `ht`, `wget` and `fetch`)
 * JSON output
 * ASN, country and city lookup using the MaxMind GeoIP database
 * Port testing

--- a/http/http.go
+++ b/http/http.go
@@ -317,7 +317,7 @@ func NotFoundHandler(w http.ResponseWriter, r *http.Request) *appError {
 func cliMatcher(r *http.Request) bool {
 	ua := useragent.Parse(r.UserAgent())
 	switch ua.Product {
-	case "curl", "HTTPie", "Wget", "fetch libfetch", "Go", "Go-http-client", "ddclient", "Mikrotik":
+	case "curl", "HTTPie", "httpie-go", "Wget", "fetch libfetch", "Go", "Go-http-client", "ddclient", "Mikrotik":
 		return true
 	}
 	return false

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -214,6 +214,7 @@ func TestCLIMatcher(t *testing.T) {
 		{"Wget", true},
 		{"fetch libfetch/2.0", true},
 		{"HTTPie/0.9.3", true},
+		{"httpie-go/0.6.0", true},
 		{"Go 1.1 package http", true},
 		{"Go-http-client/1.1", true},
 		{"Go-http-client/2.0", true},

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         <h1>What is my IP address?</h1>
         <p><code class="ip">{{ .IP }}</code></p>
         <p>Multiple command line HTTP clients are supported,
-          including <a href="https://curl.haxx.se/">curl</a>, <a href="https://github.com/jkbrzt/httpie">httpie</a>, <a href="https://www.gnu.org/software/wget/">GNU
+          including <a href="https://curl.haxx.se/">curl</a>, <a href="https://github.com/jkbrzt/httpie">httpie</a>, <a href="https://github.com/nojima/httpie-go">httpie-go</a>, <a href="https://www.gnu.org/software/wget/">GNU
             Wget</a>, <a href="https://www.freebsd.org/cgi/man.cgi?fetch(1)">fetch</a>, and <a href="https://github.com/astaxie/bat">bat</a>.</p>
         <p>All endpoints (except <code>/port</code>) can return information about a custom IP address specified via <code>?ip=</code> query parameter.</p>
       </div>
@@ -95,6 +95,9 @@ $ curl {{ .Host }}
 {{ .IP }}
 
 $ http -b {{ .Host }}
+{{ .IP }}
+
+$ ht -b {{ .Host }}
 {{ .IP }}
 
 $ wget -qO- {{ .Host }}


### PR DESCRIPTION
This adds support for the [httpie-go](https://github.com/nojima/httpie-go) cli client, as well as documentation and tests surrounding it.
I have a version of this patched version live and have also tested it manually.