### PR TITLE
introduce subresource integrity

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <title>What is my IP address? &mdash; {{ .Host }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="What is my IP address?">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/pure-min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/grids-responsive-min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans" integrity="sha384-IL0QWVE358zSFpPhnzSOq+Fb0tBsBCW9cgOfJcUy6xOGUtEY02XEbz+kPcc2ehnP" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/pure-min.css" integrity="sha384-nn4HPE8lTHyVtfCBi5yW9d20FjT8BJwUXyWZT9InLYax14RDjBj46LmSztkmNP9w" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/grids-responsive-min.css" integrity="sha384-b92sF+wDNTHrfEtRaYo+EpcA8FUyHOSXrdxKc9XB9kaaX1rSQAgMevW6cYeE5Bdv" crossorigin="anonymous">
     <style>
       html, .pure-g [class *= "pure-u"] {
         background-color: white;


### PR DESCRIPTION
added [integrity](https://developer.mozilla.org/de/docs/Web/Security/Subresource_Integrity) tags to external resources, so browser refuse to load content in case of SHA384 mismatch