### PR TITLE
Implement `/asn-org` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Bornyasherk
 
 $ curl ifconfig.co/asn
 AS59795
+
+$ curl ifconfig.co/asn-org
+Hosting4Real
 ```
 
 As JSON:

--- a/http/http.go
+++ b/http/http.go
@@ -240,6 +240,15 @@ func (s *Server) CLIASNHandler(w http.ResponseWriter, r *http.Request) *appError
 	return nil
 }
 
+func (s *Server) CLIASNOrgHandler(w http.ResponseWriter, r *http.Request) *appError {
+	response, err := s.newResponse(r)
+	if err != nil {
+		return badRequest(err).WithMessage(err.Error()).AsJSON()
+	}
+	fmt.Fprintf(w, "%s\n", response.ASNOrg)
+	return nil
+}
+
 func (s *Server) JSONHandler(w http.ResponseWriter, r *http.Request) *appError {
 	response, err := s.newResponse(r)
 	if err != nil {
@@ -431,6 +440,7 @@ func (s *Server) Handler() http.Handler {
 		r.Route("GET", "/city", s.CLICityHandler)
 		r.Route("GET", "/coordinates", s.CLICoordinatesHandler)
 		r.Route("GET", "/asn", s.CLIASNHandler)
+		r.Route("GET", "/asn-org", s.CLIASNOrgHandler)
 	}
 
 	// Browser

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -94,6 +94,7 @@ func TestCLIHandlers(t *testing.T) {
 		{s.URL + "/city", "Bornyasherk\n", 200, "", ""},
 		{s.URL + "/foo", "404 page not found", 404, "", ""},
 		{s.URL + "/asn", "AS59795\n", 200, "", ""},
+		{s.URL + "/asn-org", "Hosting4Real\n", 200, "", ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Simple stuff: `curl ifconfig.co/asn-org`, get back the org your ASN is assigned to.

Solves  #148