### PR TITLE
Allow request IP candidates to contain ports

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -99,7 +99,11 @@ func ipFromRequest(headers []string, r *http.Request, customIP bool) (net.IP, er
 		}
 	}
 	if remoteIP == "" {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		remoteIP = r.RemoteAddr
+	}
+	sep := strings.Index(remoteIP, ":")
+	if sep != -1 {
+		host, _, err := net.SplitHostPort(remoteIP)
 		if err != nil {
 			return nil, err
 		}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -217,16 +217,22 @@ func TestIPFromRequest(t *testing.T) {
 		trustedHeaders []string
 		out            string
 	}{
-		{"127.0.0.1:9999", "", "", nil, "127.0.0.1"},                                                                // No header given
-		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7", nil, "127.0.0.1"},                                                // Trusted header is empty
-		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7", []string{"X-Foo-Bar"}, "127.0.0.1"},                              // Trusted header does not match
-		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7", []string{"X-Real-IP", "X-Forwarded-For"}, "1.3.3.7"},             // Trusted header matches
-		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7", []string{"X-Real-IP", "X-Forwarded-For"}, "1.3.3.7"},       // Second trusted header matches
-		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7,4.2.4.2", []string{"X-Forwarded-For"}, "1.3.3.7"},            // X-Forwarded-For with multiple entries (commas separator)
-		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7, 4.2.4.2", []string{"X-Forwarded-For"}, "1.3.3.7"},           // X-Forwarded-For with multiple entries (space+comma separator)
-		{"127.0.0.1:9999", "X-Forwarded-For", "", []string{"X-Forwarded-For"}, "127.0.0.1"},                         // Empty header
-		{"127.0.0.1:9999?ip=1.2.3.4", "", "", nil, "1.2.3.4"},                                                       // passed in "ip" parameter
-		{"127.0.0.1:9999?ip=1.2.3.4", "X-Forwarded-For", "1.3.3.7,4.2.4.2", []string{"X-Forwarded-For"}, "1.2.3.4"}, // ip parameter wins over X-Forwarded-For with multiple entries
+		{"127.0.0.1:9999", "", "", nil, "127.0.0.1"},                                                                               // No header given
+		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7", nil, "127.0.0.1"},                                                               // Trusted header is empty
+		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7", []string{"X-Foo-Bar"}, "127.0.0.1"},                                             // Trusted header does not match
+		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7", []string{"X-Real-IP", "X-Forwarded-For"}, "1.3.3.7"},                            // Trusted header matches
+		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7", []string{"X-Real-IP", "X-Forwarded-For"}, "1.3.3.7"},                      // Second trusted header matches
+		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7,4.2.4.2", []string{"X-Forwarded-For"}, "1.3.3.7"},                           // X-Forwarded-For with multiple entries (commas separator)
+		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7, 4.2.4.2", []string{"X-Forwarded-For"}, "1.3.3.7"},                          // X-Forwarded-For with multiple entries (space+comma separator)
+		{"127.0.0.1:9999", "X-Forwarded-For", "", []string{"X-Forwarded-For"}, "127.0.0.1"},                                        // Empty header
+		{"127.0.0.1:9999", "X-Real-IP", "1.3.3.7:1337", []string{"X-Real-IP", "X-Forwarded-For"}, "1.3.3.7"},                       // Trusted header matches (with port)
+		{"127.0.0.1:9999?ip=1.2.3.4", "", "", nil, "1.2.3.4"},                                                                      // passed in "ip" parameter
+		{"127.0.0.1:9999?ip=1.2.3.4", "X-Forwarded-For", "1.3.3.7,4.2.4.2", []string{"X-Forwarded-For"}, "1.2.3.4"},                // ip parameter wins over X-Forwarded-For with multiple entries
+		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7:1337", []string{"X-Real-IP", "X-Forwarded-For"}, "1.3.3.7"},                 // Second trusted header matches (with port)
+		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7:1337,4.2.4.2:4242", []string{"X-Forwarded-For"}, "1.3.3.7"},                 // X-Forwarded-For with multiple entries (commas separator, with port)
+		{"127.0.0.1:9999", "X-Forwarded-For", "1.3.3.7:1337, 4.2.4.2:4242", []string{"X-Forwarded-For"}, "1.3.3.7"},                // X-Forwarded-For with multiple entries (space+comma separator, with port)
+		{"127.0.0.1:9999?ip=1.2.3.4:1234", "", "", nil, "1.2.3.4"},                                                                 // passed in "ip" parameter (with port)
+		{"127.0.0.1:9999?ip=1.2.3.4:1234", "X-Forwarded-For", "1.3.3.7:1337,4.2.4.2:4242", []string{"X-Forwarded-For"}, "1.2.3.4"}, // ip parameter wins over X-Forwarded-For with multiple entries (with port)
 	}
 	for _, tt := range tests {
 		u, err := url.Parse("http://" + tt.remoteAddr)


### PR DESCRIPTION
This makes `http.Request.RemoteAddr` just one candidate for the IP grabbed from the current request, instead of treating it as a special case to be run through `net.SplitHostPort`, which is now instead used on all `remoteIP` candidates regardless of source.

The motivation behind this is that Azure Application Gateways add the `X-Forwarded-For` header as a comma separated list of `IP:port` instead of each entry just containing the IP address ([ref](https://learn.microsoft.com/en-us/azure/application-gateway/how-application-gateway-works#modifications-to-the-request)), making it difficult to deploy echoip as an Azure Web App.


