### PR TITLE
Use available width when sponsor is disabled

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -32,7 +32,7 @@
   <body>
     <div class="content">
       <div class="pure-g gutters center">
-        <div class="pure-u-1 pure-u-md-2-3">
+        <div class="pure-u-1 {{ if .Sponsor }}pure-u-md-2-3{{ end }}">
           <div class="l-box">
             <h1>{{ .Host }} — What is my IP address?</h1>
             <p><code class="ip">{{ .IP }}</code></p>
@@ -42,8 +42,8 @@
             </p>
           </div>
         </div>
+        {{ if .Sponsor }}
         <div class="pure-u-1 pure-u-md-1-3">
-          {{ if .Sponsor }}
           <div class="l-box leafcloud-placement">
             <div class="pure-g">
               <div class="pure-u pure-u-md-1">
@@ -63,8 +63,8 @@
               </div>
             </div>
           </div>
-          {{ end }}
         </div>
+        {{ end }}
       </div>
 
       <div class="pure-g gutters center">


### PR DESCRIPTION
This makes sure a v6 address doesn't line break on desktop. 
Inspired on: https://github.com/mpolden/echoip/commit/7d5d21de5278e800647d9cbc3f7f2694b158da3d

This PR contains only the specific design change of #170 

Currently live on https://echoip.deovero.io/

![Screenshot 2025-01-22 at 21 20 11](https://github.com/user-attachments/assets/091a5248-9a52-48f8-ac16-cdac7881092e)
