### PR TITLE
Fix for values in info-table being cut off on Webkit

### DIFF
--- a/html/styles.html
+++ b/html/styles.html
@@ -61,6 +61,10 @@
     text-align: left;
   }
 
+  .info-table td {
+    overflow-wrap: anywhere;
+  }
+
   .widgetbox {
     width: 100%;
     padding: 0.5rem;


### PR DESCRIPTION
When you have a long reverse DNS the value was cut off.
This screenshot is taken on the current live version on https://ifconfig.co

This PR fixes this issue, is live on https://echoip.deovero.io/

![Screenshot 2025-01-22 at 22 53 38](https://github.com/user-attachments/assets/bdac48e3-5533-403f-9b81-04ee7bda09eb)
