### PR TITLE
build: Update geoip download task to use basic auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,11 @@ $(databases):
 ifndef GEOIP_LICENSE_KEY
 	$(error GEOIP_LICENSE_KEY must be set. Please see https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)
 endif
+ifndef MAXMIND_ACCOUNT_ID
+	$(error MAXMIND_ACCOUNT_ID must be set. Please see https://dev.maxmind.com/geoip/updating-databases/#directly-downloading-databases)
+endif
 	mkdir -p data
-	@curl -fsSL -m 30 "https://download.maxmind.com/app/geoip_download?edition_id=$@&license_key=$(GEOIP_LICENSE_KEY)&suffix=tar.gz" | tar $(TAR_OPTS) --strip-components=1 -C $(CURDIR)/data -xzf - '*.mmdb'
+	@curl -fsSL -m 30 -u $(MAXMIND_ACCOUNT_ID):$(GEOIP_LICENSE_KEY) "https://download.maxmind.com/geoip/databases/$@/download?suffix=tar.gz" | tar $(TAR_OPTS) --strip-components=1 -C $(CURDIR)/data -xzf - '*.mmdb'
 	test ! -f data/GeoLite2-City.mmdb || mv data/GeoLite2-City.mmdb data/city.mmdb
 	test ! -f data/GeoLite2-Country.mmdb || mv data/GeoLite2-Country.mmdb data/country.mmdb
 	test ! -f data/GeoLite2-ASN.mmdb || mv data/GeoLite2-ASN.mmdb data/asn.mmdb


### PR DESCRIPTION
Maxmind has changed the direct download process https://dev.maxmind.com/geoip/updating-databases/#directly-downloading-databases and no longer supports passing the credentials as URL paramaters.